### PR TITLE
fix-listModelSummary

### DIFF
--- a/R/InterMineR.R
+++ b/R/InterMineR.R
@@ -98,6 +98,9 @@ listModelSummary <- function(model){
                 })
   
   names(att) <- class.name
+  for(x in names(att)){
+    try(att[[x]][,"term"]<-NULL,TRUE)
+  }
   
   att.ext <- rep(list(NULL), length(class.name))
   att.ext <- lapply(class.name, function(x){


### PR DESCRIPTION
Error occurring when using getModel() with HumanMine and FlyMine. getModel() uses listModelSummary function. Inside the last one, in att.ext we could find different dimensions for some classes (Nx3 or Nx4 as there was an extra collumn called "term"). 
Having done this the function listDatasets() from the package now works. 